### PR TITLE
UI bug fix: container overflow and app padding

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,6 +21,8 @@ const { modalState, hideModal } = useModal()
 
 <style scoped>
 #app {
-  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/src/components/SongsView.vue
+++ b/src/components/SongsView.vue
@@ -377,6 +377,10 @@ const filteredSongs = computed(() => {
   padding: 20px;
   max-width: 1200px;
   margin: 0 auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 }
 
 .header {
@@ -523,6 +527,7 @@ const filteredSongs = computed(() => {
   overflow-x: auto;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   border-radius: 8px;
+  height: 100%;
 }
 
 table {

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,7 @@
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #f4f4f9;
-  padding: 20px;
+  /* padding: 20px; */
   margin: 0;
 }
 


### PR DESCRIPTION
## 修复 2 个 UI bug

- 去掉了全局留白，增加窗口的有效可视区域，去掉了由于留白挤占可视区域而出现的无意义的滚动条
- songs-view 增加高度自适应，避免出现内联 popup 被遮挡的情况

## 目前的样式

<img width="1194" height="697" alt="image" src="https://github.com/user-attachments/assets/2226cc25-87bf-4553-a2ba-b443f89ac43f" />

## 修复后的样式

<img width="1049" height="780" alt="image" src="https://github.com/user-attachments/assets/3ff0c3c1-11fb-459c-9361-b47dd441cb81" />
